### PR TITLE
:hammer: Refactor: correct typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then `pic-migrater` will registe a command named `migrate`.
 
 Please configurate this plugin first!
 
-After migrating, a new markdown file will be written in the same folder. So you should configurate this new file name's prefix first.
+After migrating, a new markdown file will be written in the same folder. So you should configurate this new file name's suffix first.
 
 ### CLI
 
@@ -61,11 +61,11 @@ Open the setting page in the menu of the plugin.
 
 ### Details
 
-#### newFilePrefix
+#### newFileSuffix
 
 ![](https://raw.githubusercontent.com/Molunerfinn/test/master/test/CLI-prefix.png)
 
-For example, if your origin file named `2019.md` & if you set the `newFilePrefix` to `_new`, then after migrating, a new file named `2019_new.md` will be created.
+For example, if your origin file named `2019.md` & if you set the `newFileSuffix` to `_new`, then after migrating, a new file named `2019_new.md` will be created.
 
 #### include
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -59,13 +59,13 @@ picgo set plugin pic-migrater
 
 ### 配置详情
 
-#### newFilePrefix
+#### newFileSuffix
 
 > 新文件名的前缀
 
 ![](https://raw.githubusercontent.com/Molunerfinn/test/master/test/CLI-prefix.png)
 
-举个例子，如果你原本的文件名为 `2019.md` 并且你将 `newFilePrefix` 设置成 `_new`，那么迁移过后，将会生成一个叫做 `2019_new.md` 的新文件。
+举个例子，如果你原本的文件名为 `2019.md` 并且你将 `newFileSuffix` 设置成 `_new`，那么迁移过后，将会生成一个叫做 `2019_new.md` 的新文件。
 
 #### include
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -43,7 +43,7 @@ picgo install pic-migrater
 
 使用之前请配置一下插件！
 
-因为在迁移某个markdown文件里的图片之后会在同一个文件夹里生成一个新的markdown文件（防止原本文件丢失）。所以你要配置一下这个新的文件的文件名前缀。
+因为在迁移某个markdown文件里的图片之后会在同一个文件夹里生成一个新的markdown文件（防止原本文件丢失）。所以你要配置一下这个新的文件的文件名后缀。
 
 ### 命令行
 
@@ -61,7 +61,7 @@ picgo set plugin pic-migrater
 
 #### newFileSuffix
 
-> 新文件名的前缀
+> 新文件名的后缀
 
 ![](https://raw.githubusercontent.com/Molunerfinn/test/master/test/CLI-prefix.png)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ const config = (ctx: picgo): PluginConfig[] => {
   const config = [
     {
       name: 'newFileSuffix',
-      alias: '文件名前缀',
+      alias: '文件名后缀',
       type: 'input',
       default: userConfig.newFileSuffix || '_new',
       required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,10 +122,10 @@ const config = (ctx: picgo): PluginConfig[] => {
   }
   const config = [
     {
-      name: 'newFilePrefix',
+      name: 'newFileSuffix',
       alias: '文件名前缀',
       type: 'input',
-      default: userConfig.newFilePrefix || '_new',
+      default: userConfig.newFileSuffix || '_new',
       required: false
     },
     {

--- a/src/lib/FileHandler.ts
+++ b/src/lib/FileHandler.ts
@@ -35,10 +35,10 @@ class FileHandler {
     }
   }
 
-  write (file: string, data: string, newPrefix = '_new') {
+  write (file: string, data: string, newSuffix = '_new') {
     const baseName = path.basename(file, '.md')
     const dirName = path.dirname(file)
-    const resultFileName = path.join(dirName, baseName + newPrefix + '.md')
+    const resultFileName = path.join(dirName, baseName + newSuffix + '.md')
     try {
       fs.writeFileSync(resultFileName, data, 'utf8')
       this.ctx.log.success(`Write ${resultFileName} successfully`)


### PR DESCRIPTION
利用 `find . -type f | xargs grep -in Prefix` 和 `find . -type f | xargs grep -n 前缀` 查找的修改文件，修改 [ 前缀及其英文单词 `prefix`  ] 为 [ 后缀和 `suffix` ]

**以下是搜到 `prefix` 但我未改动的地方**(可能需要后续改动？):

./yarn.lock:1795:    global-prefix "^1.0.1"
./yarn.lock:1799:global-prefix@^1.0.1:
./yarn.lock:1801:  resolved "https://registry.npm.taobao.org/global-prefix/download/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"

**还需要改动的示范图片（2张）**
./README.md:66:![](https://raw.githubusercontent.com/Molunerfinn/test/master/test/CLI-prefix.png)
./README_CN.md:66:![](https://raw.githubusercontent.com/Molunerfinn/test/master/test/CLI-prefix.png)

