### PR TITLE
:bug: Fix: replaceAll bugs when url has some special chars

### DIFF
--- a/src/lib/Migrater.ts
+++ b/src/lib/Migrater.ts
@@ -123,7 +123,7 @@ class Migrater {
   async handlePicFromURL (url: string) {
     try {
       let buffer = await this.getPicFromURL(url)
-      let fileName = path.basename(url).split('?')[0]
+      let fileName = path.basename(url).split('?')[0].split('#')[0]
       let imgSize = probe.sync(buffer)
       return {
         buffer,


### PR DESCRIPTION
当链接中包含有锚点信息时候会报错例如
`https://cdn.nlark.com/yuque/0/2020/jpeg/292493/1604804227362-0a6030ac-cf14-4052-8a4b-87eec4e1a904.jpeg#align=left&display=inline&height=423&margin=%5Bobject%20Object%5D&name=01_%E9%93%BE%E8%A1%A8-%E5%8D%95%E9%93%BE%E8%A1%A8.jpg&originHeight=423&originWidth=3303&size=266783&status=done&style=none&width=3303`